### PR TITLE
print ls result with no limitation of name width.

### DIFF
--- a/gshell/__init__.py
+++ b/gshell/__init__.py
@@ -135,7 +135,7 @@ def cmd_rm(filename, recursive):
 @cli.command(name='ll', help='list files in detail')
 def cmd_ll():
     cwd = getcwd()
-    cmd = '''{exe} list --query "trashed = false and '{pid}' in parents" --max 100'''\
+    cmd = '''{exe} list --query "trashed = false and '{pid}' in parents" --max 100 --name-width 0'''\
         .format(exe=DRIVE_EXE, pid=cwd['id'])
     subprocess.call(cmd, shell=True)
 
@@ -148,7 +148,7 @@ def cmd_ls(path):
         id = cwd['id']
     else:
         id = get_id_by_path(path)
-    cmd = '''{exe} list --query "trashed = false and '{pid}' in parents" --max 100'''\
+    cmd = '''{exe} list --query "trashed = false and '{pid}' in parents" --max 100 --name-width 0'''\
         .format(exe=DRIVE_EXE, pid=id)
     stdout = subprocess.check_output(cmd, shell=True).decode('utf-8')
     lines = stdout.splitlines()
@@ -212,7 +212,7 @@ def get_id_by_path(path):
 
 def get_id_by_name(name, cwd=None):
     cwd = cwd or getcwd()
-    cmd = '''{exe} list --query "trashed = false and '{pid}' in parents" --max 100'''\
+    cmd = '''{exe} list --query "trashed = false and '{pid}' in parents" --max 100 --name-width 0'''\
         .format(exe=DRIVE_EXE, pid=cwd['id'])
     stdout = subprocess.check_output(cmd, shell=True).decode('utf-8')
     lines = stdout.splitlines()


### PR DESCRIPTION
before PR
```
murooka@murooka-ThinkPad-P50:/usr/local/lib/python2.7/dist-packages/gshell/bin$ gshell ls
results20161102_bat...p_size_5_n_steps_8
results20161102_bat...p_size_5_n_steps_4
results20161102_bat..._size_2_n_steps_20
results20161102_bat..._size_2_n_steps_10
results20161102_bat..._size_1_n_steps_40
results20161102_bat..._size_1_n_steps_20
results20161104_dat...size_100_n_steps_1
results20161102_bat...size_100_n_steps_1
results20161102_dat...size_100_n_steps_1
results20161101_n_s...ata_100_alpha_1e-5
results20161101_n_s...ata_100_alpha_1e-4
results20161101_n_steps_1_n_data_100
results20161101_n_steps_1_n_data_1
results20161030_dat..._terminate_step_40
results20161027_dat...ize_5_pretrained_1
```

after PR
```
murooka@murooka-ThinkPad-P50:/usr/local/lib/python2.7/dist-packages/gshell/bin$ gshell ls
results20161102_batch_size_1_pretrained_dataset_100_step_size_5_n_steps_8
results20161102_batch_size_1_pretrained_dataset_100_step_size_5_n_steps_4
results20161102_batch_size_1_pretrained_dataset_100_step_size_2_n_steps_20
results20161102_batch_size_1_pretrained_dataset_100_step_size_2_n_steps_10
results20161102_batch_size_1_pretrained_dataset_100_step_size_1_n_steps_40
results20161102_batch_size_1_pretrained_dataset_100_step_size_1_n_steps_20
results20161104_dataset_10000_batch_size_10_step_size_100_n_steps_1
results20161102_batch_size_1_pretrained_dataset_100_step_size_100_n_steps_1
results20161102_dataset_2000_batch_size_10_step_size_100_n_steps_1
results20161101_n_steps_1_n_data_100_alpha_1e-5
results20161101_n_steps_1_n_data_100_alpha_1e-4
results20161101_n_steps_1_n_data_100
results20161101_n_steps_1_n_data_1
results20161030_dataset_1_batch_size_1_step_size_1_terminate_step_40
results20161027_dataset_2000_batch_size_5_pretrained_1
```

`--name-width 0` option means full width.
```
murooka@murooka-ThinkPad-P50:/usr/local/lib/python2.7/dist-packages/gshell/bin$ ./_gshell_drive-linux-x64 help list
List files
gdrive [global] list [options]

global:
  -c, --config <configDir>         Application path, default: /home/murooka/.gdrive
  --refresh-token <refreshToken>   Oauth refresh token used to get access token (for advanced users)
  --access-token <accessToken>     Oauth access token, only recommended for short-lived requests because of short lifetime (for advanced users)

options:
  -m, --max <maxFiles>       Max files to list, default: 30
  -q, --query <query>        Default query: "trashed = false and 'me' in owners". See https://developers.google.com/drive/search-parameters
  --order <sortOrder>        Sort order. See https://godoc.org/google.golang.org/api/drive/v3#FilesListCall.OrderBy
  --name-width <nameWidth>   Width of name column, default: 40, minimum: 9, use 0 for full width
  --absolute                 Show absolute path to file (will only show path from first parent)
  --no-header                Dont print the header
  --bytes                    Size in bytes
```
